### PR TITLE
fix: faster training with no performance loss

### DIFF
--- a/code/scripts/rlvr_deepscaler_grpo_qwen_ground_truth.sh
+++ b/code/scripts/rlvr_deepscaler_grpo_qwen_ground_truth.sh
@@ -50,7 +50,7 @@ python -m ttrl.cli.train_ppo_naive \
    --micro_rollout_batch_size 4 \
    --rollout_batch_size 64 \
    --n_samples_per_prompt 16 \
-   --n_votes_per_prompt 64 \
+   --n_votes_per_prompt 16 \
    --extra_eval_task_fast "test,AIME2025-TTT@8,AIME-TTT@8,AMC-TTT@8,AMC-TTT@1,MATH-TTT@1" \
    --extra_eval_task_fast_supress_orig_eval \
    --eval_temperature_at_k 0.6 \


### PR DESCRIPTION
# Optimizing Sampling Efficiency: Reducing n_votes_per_prompt from 64 to 16

## Rationale

As documented in the TTRL repository issue ([#16](https://github.com/PRIME-RL/TTRL/issues/16)), the current implementation uses `n_votes_per_prompt` (64) samples to generate an estimated label. Subsequently, `n_samples_per_prompt` (16) samples are selected to calculate the reward (using the estimated label as ground truth) and train the model.

## Proposed Optimization

There is no benefit to maintaining `n_votes_per_prompt` at a higher value than `n_samples_per_prompt` when not utilizing TTRL's majority voting reward function. The current configuration creates unnecessary computational overhead.

## Expected Benefits

Reducing `n_votes_per_prompt` from 64 to 16 (matching `n_samples_per_prompt`) will:
- Accelerate sampling time by approximately 4x
- Maintain equivalent model performance
- Improve training efficiency without sacrificing quality

This optimization represents a significant improvement in computational efficiency with no performance tradeoffs.